### PR TITLE
docs: document Nix installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 Drop-in ROS 2 bridge for [Rerun](https://rerun.io) — no ROS 2 runtime or build required.
 
-Stream live ROS 2 topics to the Rerun viewer for real-time visualization. Supports 59 built-in
+Stream live ROS 2 topics to the Rerun viewer for real-time visualization. Supports 74 built-in
 ROS 2 type mappings out of the box, with extensibility for custom messages.
 
 ## Features
 
 - Zero ROS 2 dependency — pure Rust, no colcon or ament needed
 - Automatic DDS and Zenoh discovery
-- More than 50 built-in type mappings across
+- 74 built-in type mappings across the common ROS 2 interface packages
 - Custom message support via JSON5 mappings
 - Real-time diagnostics (hz, bytes/sec, drops, latency)
 - Topic filtering with glob patterns
@@ -24,10 +24,11 @@ See the [documentation](https://rewire.run) for installation instructions and us
 
 ### Nix
 
-This repository is a flake. rewire is unfree, so `allowUnfree` is required.
+This repository is a flake.
 
 ```bash
-nix profile install github:rewire-run/rewire
+nix run github:rewire-run/rewire -- --version   # try it, installs nothing
+nix profile add github:rewire-run/rewire        # install for the current user
 ```
 
 On NixOS, add it as an input and pull the package into your system config:
@@ -38,7 +39,6 @@ On NixOS, add it as an input and pull the package into your system config:
 
   # in your nixosConfiguration modules
   environment.systemPackages = [ inputs.rewire.packages.${system}.rewire ];
-  nixpkgs.config.allowUnfree = true;
 }
 ```
 
@@ -46,7 +46,12 @@ An overlay is also exported, if you would rather reach it as `pkgs.rewire`:
 
 ```nix
 nixpkgs.overlays = [ inputs.rewire.overlays.default ];
+nixpkgs.config.allowUnfree = true;
 ```
+
+rewire is unfree. The commands and the `packages` output above allow it for their own nixpkgs
+instance and need nothing from you. The overlay puts rewire on your `pkgs`, so that route alone
+needs `allowUnfree` in your own configuration.
 
 Binaries come from this repository's releases; nothing is built from source. Supported systems are
 listed in [`sources.json`](sources.json), which is regenerated on every release.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,35 @@ ROS 2 type mappings out of the box, with extensibility for custom messages.
 
 See the [documentation](https://rewire.run) for installation instructions and usage.
 
+### Nix
+
+This repository is a flake. rewire is unfree, so `allowUnfree` is required.
+
+```bash
+nix profile install github:rewire-run/rewire
+```
+
+On NixOS, add it as an input and pull the package into your system config:
+
+```nix
+{
+  inputs.rewire.url = "github:rewire-run/rewire";
+
+  # in your nixosConfiguration modules
+  environment.systemPackages = [ inputs.rewire.packages.${system}.rewire ];
+  nixpkgs.config.allowUnfree = true;
+}
+```
+
+An overlay is also exported, if you would rather reach it as `pkgs.rewire`:
+
+```nix
+nixpkgs.overlays = [ inputs.rewire.overlays.default ];
+```
+
+Binaries come from this repository's releases; nothing is built from source. Supported systems are
+listed in [`sources.json`](sources.json), which is regenerated on every release.
+
 ## Related Repositories
 
 | Repository | Description |


### PR DESCRIPTION
Documents installing rewire with Nix, covering `nix profile install`, the NixOS flake input, and the exported overlay. rewire is unfree, so the section calls out `allowUnfree`.

The flake itself is authored in bridge under `packaging/nix/` and published here by the mirror workflow, so this PR is docs only.